### PR TITLE
Add web-based 3D demo

### DIFF
--- a/demo_game.html
+++ b/demo_game.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>3D Demo Game</title>
+<style>
+body { margin: 0; overflow: hidden; }
+canvas { display: block; }
+</style>
+</head>
+<body>
+<script type="module">
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.155.0/build/three.module.js';
+import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.155.0/examples/jsm/controls/PointerLockControls.js';
+import * as CANNON from 'https://cdn.jsdelivr.net/npm/cannon-es@0.20.0/dist/cannon-es.js';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0xbfd1e5);
+
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const world = new CANNON.World({ gravity: new CANNON.Vec3(0, 0, -9.82) });
+
+const floorGeo = new THREE.PlaneGeometry(50, 50);
+const floorMat = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
+const floorMesh = new THREE.Mesh(floorGeo, floorMat);
+floorMesh.rotation.x = -Math.PI / 2;
+scene.add(floorMesh);
+const floorShape = new CANNON.Plane();
+const floorBody = new CANNON.Body({ mass: 0, shape: floorShape });
+floorBody.quaternion.setFromEuler(-Math.PI / 2, 0, 0);
+world.addBody(floorBody);
+
+const cubes = [];
+const cubeBodies = [];
+const colors = Array.from({ length: 25 }, (_, i) => new THREE.Color(`hsl(${i * 14}, 80%, 60%)`));
+for (let i = 0; i < 25; i++) {
+  const boxGeo = new THREE.BoxGeometry(1, 1, 1);
+  const boxMat = new THREE.MeshStandardMaterial({ color: colors[i] });
+  const mesh = new THREE.Mesh(boxGeo, boxMat);
+  mesh.position.set((i % 5) * 2 - 4, Math.floor(i / 5) * 2 - 4, 5 + Math.random() * 2);
+  scene.add(mesh);
+  cubes.push(mesh);
+
+  const shape = new CANNON.Box(new CANNON.Vec3(0.5, 0.5, 0.5));
+  const body = new CANNON.Body({ mass: 1 });
+  body.addShape(shape);
+  body.position.copy(mesh.position);
+  world.addBody(body);
+  cubeBodies.push(body);
+}
+
+const ambient = new THREE.AmbientLight(0xffffff, 0.4);
+scene.add(ambient);
+const light = new THREE.DirectionalLight(0xffffff, 0.8);
+light.position.set(5, 5, 10);
+scene.add(light);
+
+const controls = new PointerLockControls(camera, renderer.domElement);
+document.addEventListener('click', () => controls.lock());
+camera.position.set(0, 0, 2);
+
+const velocity = new THREE.Vector3();
+const direction = new THREE.Vector3();
+
+function onKeyDown(event) {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW':
+      velocity.z = -5;
+      break;
+    case 'ArrowLeft':
+    case 'KeyA':
+      velocity.x = -5;
+      break;
+    case 'ArrowDown':
+    case 'KeyS':
+      velocity.z = 5;
+      break;
+    case 'ArrowRight':
+    case 'KeyD':
+      velocity.x = 5;
+      break;
+  }
+}
+function onKeyUp(event) {
+  switch (event.code) {
+    case 'ArrowUp':
+    case 'KeyW':
+    case 'ArrowDown':
+    case 'KeyS':
+      velocity.z = 0;
+      break;
+    case 'ArrowLeft':
+    case 'KeyA':
+    case 'ArrowRight':
+    case 'KeyD':
+      velocity.x = 0;
+      break;
+  }
+}
+document.addEventListener('keydown', onKeyDown);
+document.addEventListener('keyup', onKeyUp);
+
+const clock = new THREE.Clock();
+
+function animate() {
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  if (controls.isLocked) {
+    direction.z = velocity.z * delta;
+    direction.x = velocity.x * delta;
+    controls.moveRight(direction.x);
+    controls.moveForward(-direction.z);
+  }
+  world.step(1 / 60, delta);
+  for (let i = 0; i < cubes.length; i++) {
+    cubes[i].position.copy(cubeBodies[i].position);
+    cubes[i].quaternion.copy(cubeBodies[i].quaternion);
+  }
+  renderer.render(scene, camera);
+}
+
+animate();
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
+</script>
+</body>
+</html>

--- a/demo_game.py
+++ b/demo_game.py
@@ -1,0 +1,101 @@
+from direct.showbase.ShowBase import ShowBase
+from panda3d.core import Vec3, Vec4, WindowProperties
+from panda3d.bullet import BulletWorld, BulletRigidBodyNode, BulletBoxShape, BulletPlaneShape
+
+
+def clamp(value: float, min_value: float, max_value: float) -> float:
+    return max(min_value, min(max_value, value))
+
+
+class MinecraftDemo(ShowBase):
+    def __init__(self):
+        ShowBase.__init__(self)
+        self.disableMouse()
+        self.accept("escape", self.userExit)
+
+        self.speed = 5
+        self.sensitivity = 0.2
+
+        self.keys = {"w": False, "a": False, "s": False, "d": False}
+        for key in self.keys:
+            self.accept(key, self._set_key, [key, True])
+            self.accept(f"{key}-up", self._set_key, [key, False])
+
+        self._setup_world()
+        self._setup_camera()
+        self.taskMgr.add(self._update, "update")
+
+    def _set_key(self, key: str, value: bool) -> None:
+        self.keys[key] = value
+
+    def _setup_world(self) -> None:
+        self.world = BulletWorld()
+        self.world.setGravity(Vec3(0, 0, -9.81))
+
+        # Ground plane
+        plane_shape = BulletPlaneShape(Vec3(0, 0, 1), 0)
+        plane_node = BulletRigidBodyNode("ground")
+        plane_node.addShape(plane_shape)
+        plane_np = self.render.attachNewNode(plane_node)
+        self.world.attachRigidBody(plane_node)
+
+        ground = self.loader.loadModel("box")
+        ground.setScale(10, 10, 0.1)
+        ground.setColor(0.5, 0.5, 0.5, 1)
+        ground.reparentTo(plane_np)
+
+        # 25 cubes with different colors
+        colors = [Vec4((i % 5) / 4, ((i // 5) % 5) / 4, (i / 24), 1) for i in range(25)]
+        for i, color in enumerate(colors):
+            shape = BulletBoxShape(Vec3(0.5, 0.5, 0.5))
+            node = BulletRigidBodyNode(f"cube{i}")
+            node.setMass(1.0)
+            node.addShape(shape)
+            np = self.render.attachNewNode(node)
+            np.setPos((i % 5) * 2 - 4, (i // 5) * 2, 1)
+            self.world.attachRigidBody(node)
+
+            model = self.loader.loadModel("box")
+            model.setColor(color)
+            model.reparentTo(np)
+
+    def _setup_camera(self) -> None:
+        self.camera.setPos(0, -10, 2)
+        props = WindowProperties()
+        props.setCursorHidden(True)
+        self.win.requestProperties(props)
+        center_x = int(self.win.getProperties().getXSize() / 2)
+        center_y = int(self.win.getProperties().getYSize() / 2)
+        self.win.movePointer(0, center_x, center_y)
+
+    def _update(self, task):
+        dt = globalClock.getDt()
+        self.world.doPhysics(dt)
+
+        # Mouse look
+        center_x = int(self.win.getProperties().getXSize() / 2)
+        center_y = int(self.win.getProperties().getYSize() / 2)
+        md = self.win.getPointer(0)
+        x = md.getX() - center_x
+        y = md.getY() - center_y
+        self.win.movePointer(0, center_x, center_y)
+        self.camera.setH(self.camera.getH() - x * self.sensitivity)
+        self.camera.setP(clamp(self.camera.getP() - y * self.sensitivity, -90, 90))
+
+        # Keyboard movement
+        direction = Vec3(0, 0, 0)
+        if self.keys["w"]:
+            direction.y += self.speed * dt
+        if self.keys["s"]:
+            direction.y -= self.speed * dt
+        if self.keys["a"]:
+            direction.x -= self.speed * dt
+        if self.keys["d"]:
+            direction.x += self.speed * dt
+        self.camera.setPos(self.camera, direction)
+
+        return task.cont
+
+
+if __name__ == "__main__":
+    MinecraftDemo().run()


### PR DESCRIPTION
## Summary
- add an HTML version of the first-person demo using Three.js and Cannon.js

## Testing
- `python3 -m py_compile demo_game.py`


------
https://chatgpt.com/codex/tasks/task_e_68805cc146f0832ab571824ac3c6f660