### PR TITLE
Add improved GrowBot Privado single-page app

### DIFF
--- a/growbot.html
+++ b/growbot.html
@@ -1,0 +1,763 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<title>GrowBot Privado</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  * { margin: 0; padding: 0; box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+
+  :root {
+    --bg: #080f08;
+    --bg2: #0d1a0d;
+    --bg3: #122012;
+    --green: #5db845;
+    --green2: #8ed46e;
+    --green3: #c4e8a8;
+    --dim: #4a7a38;
+    --dimmer: #2a4a20;
+    --border: rgba(80,180,60,0.2);
+    --border2: rgba(80,180,60,0.4);
+    --danger: #e07070;
+  }
+
+  html, body {
+    height: 100%; background: var(--bg);
+    color: var(--green3); overflow: hidden;
+    font-family: 'Crimson Pro', Georgia, serif;
+  }
+
+  #app {
+    display: flex; flex-direction: column;
+    height: 100vh; max-width: 500px;
+    margin: 0 auto; position: relative;
+  }
+
+  /* API KEY SCREEN */
+  #apiscreen {
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    height: 100vh; padding: 32px 24px; gap: 20px;
+    background: radial-gradient(circle at 50% 30%, rgba(80,160,60,0.12) 0%, transparent 60%);
+  }
+  #apiscreen .logo { font-size: 56px; }
+  #apiscreen h1 { font-size: 26px; color: var(--green2); text-align: center; letter-spacing: 1px; }
+  #apiscreen p { font-size: 14px; color: var(--dim); text-align: center; line-height: 1.7; }
+  #apiscreen a { color: var(--green); }
+  #apikey-input {
+    width: 100%; padding: 14px 16px;
+    background: rgba(20,50,20,0.6);
+    border: 1px solid var(--border2);
+    border-radius: 12px; color: var(--green3);
+    font-size: 13px; font-family: 'JetBrains Mono', monospace;
+    outline: none; letter-spacing: 1px;
+  }
+  #apikey-input::placeholder { color: var(--dimmer); letter-spacing: 0; }
+  #apikey-btn {
+    width: 100%; padding: 14px;
+    background: linear-gradient(135deg, #2d6a20, #4a9a3a);
+    border: none; border-radius: 12px;
+    color: #fff; font-size: 16px;
+    font-family: 'Crimson Pro', serif;
+    cursor: pointer; letter-spacing: 1px;
+    box-shadow: 0 0 30px rgba(80,180,60,0.3);
+  }
+  #apikey-error {
+    color: var(--danger); font-size: 13px;
+    text-align: center; min-height: 18px;
+  }
+
+  /* HEADER */
+  #header {
+    background: rgba(8,15,8,0.95);
+    border-bottom: 1px solid var(--border);
+    padding: 14px 18px 0;
+    backdrop-filter: blur(10px);
+    position: sticky; top: 0; z-index: 10;
+    flex-shrink: 0;
+  }
+  .header-top { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+  .avatar {
+    width: 40px; height: 40px; border-radius: 50%;
+    background: linear-gradient(135deg, #2d6a2d, #4a9a3a);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 20px; box-shadow: 0 0 20px rgba(80,180,60,0.4);
+    flex-shrink: 0;
+  }
+  .app-title { font-size: 15px; font-weight: 600; color: var(--green2); letter-spacing: 1px; }
+  .app-sub { font-size: 11px; color: var(--dim); }
+  .stage-badge {
+    margin-left: auto;
+    background: rgba(80,180,60,0.12);
+    border: 1px solid var(--border2);
+    border-radius: 20px; padding: 3px 10px;
+    font-size: 11px; color: var(--green2);
+    white-space: nowrap;
+  }
+  .icon-btn {
+    background: transparent; border: none;
+    color: var(--dim); cursor: pointer;
+    font-size: 16px; padding: 4px 8px;
+    font-family: inherit; border-radius: 6px;
+  }
+  .icon-btn:hover { color: var(--green2); background: rgba(80,180,60,0.08); }
+  .tabs { display: flex; gap: 8px; }
+  .tab {
+    flex: 1; padding: 8px 0;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    color: var(--dim); cursor: pointer;
+    font-size: 13px; font-family: inherit;
+    transition: all 0.2s;
+  }
+  .tab.active {
+    background: rgba(80,180,60,0.15);
+    border-color: var(--border2);
+    color: var(--green2);
+  }
+
+  /* CHAT */
+  #chat { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+  #messages {
+    flex: 1; overflow-y: auto; padding: 16px;
+    display: flex; flex-direction: column; gap: 12px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .msg { display: flex; }
+  .msg.user { justify-content: flex-end; }
+  .bubble {
+    max-width: 82%; padding: 11px 15px;
+    font-size: 15px; line-height: 1.6;
+    word-break: break-word;
+  }
+  .bubble.bot {
+    background: rgba(18,32,18,0.9);
+    border: 1px solid var(--border);
+    border-radius: 18px 18px 18px 4px;
+    color: var(--green3);
+  }
+  .bubble.user {
+    background: linear-gradient(135deg, #2a6018, #3a8025);
+    border: 1px solid rgba(80,180,60,0.35);
+    border-radius: 18px 18px 4px 18px;
+    color: #e0f4cc;
+    box-shadow: 0 4px 20px rgba(60,150,40,0.2);
+    white-space: pre-wrap;
+  }
+  .bubble.bot code {
+    background: rgba(80,180,60,0.15);
+    padding: 1px 5px; border-radius: 4px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.9em; color: var(--green2);
+  }
+  .bubble.bot strong { color: var(--green2); font-weight: 600; }
+  .bubble.bot em { color: var(--green3); }
+  .bubble.bot.error { border-color: rgba(224,112,112,0.4); color: var(--danger); }
+  .cursor {
+    display: inline-block; width: 7px; height: 14px;
+    background: var(--green2); vertical-align: -2px;
+    margin-left: 2px; animation: blink-cursor 1s steps(2) infinite;
+  }
+  @keyframes blink-cursor { 50% { opacity: 0; } }
+  .typing { display: flex; align-items: center; gap: 8px; padding: 12px 16px; }
+  .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--dim); animation: blink 1.2s infinite; }
+  .dot:nth-child(2) { animation-delay: 0.2s; }
+  .dot:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes blink { 0%,80%,100%{opacity:0.2} 40%{opacity:1} }
+
+  /* QUICK QUESTIONS */
+  #quick { padding: 4px 16px 0; display: flex; flex-wrap: wrap; gap: 6px; }
+  .qbtn {
+    padding: 6px 12px; border-radius: 20px;
+    background: rgba(30,60,20,0.5);
+    border: 1px solid var(--border2);
+    color: var(--green2); font-size: 12px;
+    cursor: pointer; font-family: inherit;
+    white-space: nowrap;
+  }
+
+  /* INPUT */
+  #inputbar {
+    padding: 12px 16px 24px;
+    background: rgba(8,15,8,0.97);
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .input-wrap {
+    display: flex; gap: 10px; align-items: flex-end;
+    background: rgba(18,32,18,0.8);
+    border: 1px solid var(--border2);
+    border-radius: 16px; padding: 10px 12px;
+  }
+  #msginput {
+    flex: 1; background: transparent;
+    border: none; outline: none;
+    color: var(--green3); font-size: 15px;
+    font-family: 'Crimson Pro', serif;
+    resize: none; line-height: 1.5;
+    max-height: 100px; overflow-y: auto;
+  }
+  #msginput::placeholder { color: var(--dimmer); }
+  #sendbtn {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: linear-gradient(135deg, #3d8a2a, #5aaa3a);
+    border: none; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 15px; flex-shrink: 0; color: #fff;
+    box-shadow: 0 0 15px rgba(80,180,60,0.4);
+    transition: all 0.2s;
+  }
+  #sendbtn:disabled { background: rgba(50,80,40,0.3); box-shadow: none; cursor: default; }
+  #sendbtn.stop { background: linear-gradient(135deg, #8a3a2a, #aa5a3a); box-shadow: 0 0 15px rgba(220,100,80,0.4); }
+  .footer-row { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; }
+  .privacy { font-size: 10px; color: var(--dimmer); }
+
+  /* PLANT TAB */
+  #planttab { overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 14px; flex: 1; }
+  .card {
+    background: rgba(18,32,18,0.7);
+    border: 1px solid var(--border);
+    border-radius: 16px; padding: 18px;
+  }
+  .card-title { font-size: 11px; color: var(--dim); text-transform: uppercase; letter-spacing: 1.5px; margin-bottom: 14px; }
+  .day-ctrl { display: flex; align-items: center; gap: 12px; }
+  .daybtn {
+    width: 38px; height: 38px; border-radius: 50%;
+    background: rgba(80,180,60,0.1);
+    border: 1px solid var(--border2);
+    color: var(--green2); font-size: 20px;
+    cursor: pointer; display: flex; align-items: center; justify-content: center;
+  }
+  #daynumber { flex: 1; text-align: center; }
+  #daynumber span { font-size: 52px; font-weight: 600; color: var(--green2); }
+  #daynumber small { font-size: 14px; color: var(--dim); margin-left: 6px; }
+  .stage-list { display: flex; flex-direction: column; gap: 7px; }
+  .stageoption {
+    display: flex; align-items: center; gap: 12px;
+    padding: 10px 13px; border-radius: 10px;
+    background: rgba(15,30,15,0.5);
+    border: 1px solid rgba(80,180,60,0.08);
+    cursor: pointer; transition: all 0.2s;
+    font-family: inherit;
+  }
+  .stageoption.selected {
+    background: rgba(80,180,60,0.18);
+    border-color: var(--border2);
+    color: var(--green2);
+  }
+  .stageoption span { flex: 1; font-size: 14px; color: var(--green3); text-align: left; }
+  .stageoption small { font-size: 11px; color: var(--dim); }
+  .info-row { display: flex; align-items: center; gap: 12px; padding: 9px 0; border-bottom: 1px solid rgba(80,180,60,0.08); }
+  .info-row:last-child { border-bottom: none; }
+  .info-icon { font-size: 20px; width: 28px; text-align: center; }
+  .info-label { font-size: 11px; color: var(--dim); }
+  .info-val { font-size: 13px; color: var(--green3); }
+  .danger-btn {
+    width: 100%; padding: 10px; margin-top: 4px;
+    background: transparent; border: 1px solid rgba(224,112,112,0.3);
+    color: var(--danger); border-radius: 10px;
+    font-family: inherit; font-size: 13px; cursor: pointer;
+  }
+  .danger-btn:hover { background: rgba(224,112,112,0.08); }
+
+  /* HIDDEN */
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+<div id="app">
+
+  <!-- API KEY SCREEN -->
+  <div id="apiscreen">
+    <div class="logo">🌿</div>
+    <h1>GrowBot Privado</h1>
+    <p>Tu asistente personal de cultivo CBD.<br>Introduce tu API key de Anthropic para empezar.</p>
+    <p style="font-size:12px">Consíguela en <a href="https://console.anthropic.com" target="_blank" rel="noopener">console.anthropic.com</a><br>Se guarda solo en tu navegador.</p>
+    <input id="apikey-input" type="password" placeholder="sk-ant-api03-..." autocomplete="off" spellcheck="false">
+    <div id="apikey-error"></div>
+    <button id="apikey-btn">Entrar 🌱</button>
+  </div>
+
+  <!-- MAIN APP -->
+  <div id="mainapp" class="hidden">
+
+    <!-- HEADER -->
+    <div id="header">
+      <div class="header-top">
+        <div class="avatar">🌿</div>
+        <div style="flex:1; min-width:0;">
+          <div class="app-title">GrowBot Privado</div>
+          <div class="app-sub">CBD Auto · Exterior · Torremolinos</div>
+        </div>
+        <div class="stage-badge" id="stagebadge">🌱 Vegetativo</div>
+        <button class="icon-btn" id="menubtn" aria-label="Opciones" title="Opciones">⋯</button>
+      </div>
+      <div class="tabs" role="tablist">
+        <button class="tab active" data-tab="chat" role="tab">💬 Asistente</button>
+        <button class="tab" data-tab="plant" role="tab">🌱 Mi Planta</button>
+      </div>
+    </div>
+
+    <!-- CHAT TAB -->
+    <div id="chat">
+      <div id="messages" aria-live="polite"></div>
+      <div id="quick"></div>
+      <div id="inputbar">
+        <div class="input-wrap">
+          <textarea id="msginput" rows="1" placeholder="Pregunta sobre tu CBD Auto..." aria-label="Mensaje"></textarea>
+          <button id="sendbtn" aria-label="Enviar">➤</button>
+        </div>
+        <div class="footer-row">
+          <div class="privacy">🔒 Solo tú y Anthropic</div>
+          <button class="icon-btn" id="clearbtn" title="Limpiar conversación" aria-label="Limpiar conversación">🗑 Limpiar</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- PLANT TAB -->
+    <div id="planttab" class="hidden">
+      <div class="card">
+        <div class="card-title">Día de cultivo</div>
+        <div class="day-ctrl">
+          <button class="daybtn" data-day="-1" aria-label="Día anterior">−</button>
+          <div id="daynumber"><span id="daynum">1</span><small>días</small></div>
+          <button class="daybtn" data-day="1" aria-label="Día siguiente">+</button>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-title">Etapa actual</div>
+        <div class="stage-list" id="stagelist"></div>
+      </div>
+      <div class="card">
+        <div class="card-title">Tu entorno — Torremolinos</div>
+        <div class="info-row"><div class="info-icon">☀️</div><div><div class="info-label">Clima</div><div class="info-val">Mediterráneo · 300+ días de sol</div></div></div>
+        <div class="info-row"><div class="info-icon">🌡️</div><div><div class="info-label">Verano</div><div class="info-val">28–40°C · Riego diario posible</div></div></div>
+        <div class="info-row"><div class="info-icon">💧</div><div><div class="info-label">Humedad</div><div class="info-val">Baja · Bajo riesgo de botritis</div></div></div>
+        <div class="info-row"><div class="info-icon">🌬️</div><div><div class="info-label">Viento</div><div class="info-val">Levante/Poniente · Proteger si fuerte</div></div></div>
+      </div>
+      <div class="card">
+        <div class="card-title">Cuenta</div>
+        <button class="danger-btn" id="logoutbtn">Cambiar API key</button>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+const STAGES = [
+  { id:"germen", label:"Germinación", days:"0–3d", emoji:"🌰" },
+  { id:"seedling", label:"Plántula", days:"3–14d", emoji:"🌱" },
+  { id:"veg", label:"Vegetativo", days:"14–35d", emoji:"🌿" },
+  { id:"preflor", label:"Prefloración", days:"35–50d", emoji:"🌸" },
+  { id:"flora", label:"Floración", days:"50–75d", emoji:"💐" },
+  { id:"cosecha", label:"Cosecha", days:"75–90d", emoji:"✂️" },
+];
+
+const QUICK = [
+  ["¿Cuándo riego hoy?", "💧"],
+  ["¿Qué nutrientes necesita ahora?", "🧪"],
+  ["¿Cómo protejo del calor?", "🌡️"],
+  ["¿Plagas comunes en Torremolinos?", "🐛"],
+  ["¿Cómo sé si está lista para cosechar?", "✂️"],
+];
+
+const SYSTEM = `Eres un experto asistente privado de cultivo de cannabis CBD. Datos fijos del cultivador:
+- Planta: CBD Auto (autofloreciente, ~70–90 días totales desde germinación, no depende del fotoperiodo)
+- Ambiente: exterior en maceta o suelo
+- Ubicación: Torremolinos, Málaga. Clima mediterráneo: 300+ días de sol, veranos muy calurosos (28–40°C), humedad baja (bajo riesgo de botritis), vientos de levante y poniente.
+- En verano puede necesitar riego diario; en primavera/otoño cada 2–3 días.
+- Nutrientes orientativos: vegetativo N alto, floración P-K altos, bajar N. Usar abonos orgánicos si es posible.
+
+Responde siempre en español, de forma práctica, breve y concreta. Usa listas cortas cuando ayuden. Habla solo de cultivo, clima, nutrición, plagas, poda, riego y cosecha. Si el usuario pregunta otra cosa, redirígele amablemente al cultivo. No des consejos médicos ni legales más allá del cultivo personal.`;
+
+const LS = {
+  key: 'growbot.apiKey',
+  day: 'growbot.day',
+  stage: 'growbot.stage',
+  history: 'growbot.history',
+};
+
+let apiKey = '';
+let plantDay = 1;
+let currentStage = 'veg';
+let history = [];
+let currentAbort = null;
+
+// ------------ persistence ------------
+function load() {
+  apiKey = localStorage.getItem(LS.key) || '';
+  plantDay = parseInt(localStorage.getItem(LS.day) || '1', 10) || 1;
+  currentStage = localStorage.getItem(LS.stage) || 'veg';
+  try { history = JSON.parse(localStorage.getItem(LS.history) || '[]'); }
+  catch { history = []; }
+}
+function saveHistory() {
+  // Cap history to avoid unbounded localStorage growth
+  const capped = history.slice(-40);
+  localStorage.setItem(LS.history, JSON.stringify(capped));
+}
+
+// ------------ API key screen ------------
+function startApp() {
+  const input = document.getElementById('apikey-input');
+  const err = document.getElementById('apikey-error');
+  const k = input.value.trim();
+  if (!k.startsWith('sk-ant-')) {
+    err.textContent = 'La API key debe empezar por sk-ant-';
+    return;
+  }
+  apiKey = k;
+  localStorage.setItem(LS.key, apiKey);
+  err.textContent = '';
+  showMain();
+}
+
+function showMain() {
+  document.getElementById('apiscreen').style.display = 'none';
+  document.getElementById('mainapp').classList.remove('hidden');
+  renderStages();
+  renderHistory();
+  renderQuick();
+  updateStageBadge();
+  document.getElementById('daynum').textContent = plantDay;
+}
+
+function logout() {
+  if (!confirm('¿Cambiar API key? Se mantendrá la conversación.')) return;
+  localStorage.removeItem(LS.key);
+  apiKey = '';
+  document.getElementById('mainapp').classList.add('hidden');
+  document.getElementById('apiscreen').style.display = 'flex';
+  document.getElementById('apikey-input').value = '';
+  document.getElementById('apikey-input').focus();
+}
+
+// ------------ plant tab ------------
+function renderStages() {
+  const list = document.getElementById('stagelist');
+  list.innerHTML = '';
+  STAGES.forEach(s => {
+    const btn = document.createElement('button');
+    btn.className = 'stageoption' + (s.id === currentStage ? ' selected' : '');
+    btn.innerHTML = `<span style="font-size:18px">${s.emoji}</span><span></span><small></small>`;
+    btn.children[1].textContent = s.label;
+    btn.children[2].textContent = s.days;
+    btn.addEventListener('click', () => selectStage(s.id));
+    list.appendChild(btn);
+  });
+}
+
+function selectStage(id) {
+  currentStage = id;
+  localStorage.setItem(LS.stage, id);
+  updateStageBadge();
+  renderStages();
+}
+
+function updateStageBadge() {
+  const s = STAGES.find(x => x.id === currentStage) || STAGES[2];
+  document.getElementById('stagebadge').textContent = `${s.emoji} ${s.label}`;
+}
+
+function changeDay(d) {
+  plantDay = Math.max(1, Math.min(120, plantDay + d));
+  localStorage.setItem(LS.day, String(plantDay));
+  document.getElementById('daynum').textContent = plantDay;
+}
+
+function showTab(tab) {
+  document.querySelectorAll('.tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.tab === tab);
+  });
+  document.getElementById('chat').classList.toggle('hidden', tab !== 'chat');
+  document.getElementById('planttab').classList.toggle('hidden', tab !== 'plant');
+}
+
+// ------------ chat rendering ------------
+function escapeHTML(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function renderMarkdown(text) {
+  let h = escapeHTML(text);
+  // Code spans
+  h = h.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+  // Bold
+  h = h.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+  // Italic
+  h = h.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, '$1<em>$2</em>');
+  // Bullet lines — lightweight
+  h = h.replace(/^[-•]\s+(.+)$/gm, '• $1');
+  // Line breaks
+  h = h.replace(/\n/g, '<br>');
+  return h;
+}
+
+function addUserMsg(text) {
+  const msgs = document.getElementById('messages');
+  const div = document.createElement('div');
+  div.className = 'msg user';
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble user';
+  bubble.textContent = text;
+  div.appendChild(bubble);
+  msgs.appendChild(div);
+  msgs.scrollTop = msgs.scrollHeight;
+}
+
+function addBotMsg(text, opts = {}) {
+  const msgs = document.getElementById('messages');
+  const div = document.createElement('div');
+  div.className = 'msg';
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble bot' + (opts.error ? ' error' : '');
+  bubble.innerHTML = renderMarkdown(text);
+  div.appendChild(bubble);
+  msgs.appendChild(div);
+  msgs.scrollTop = msgs.scrollHeight;
+  return bubble;
+}
+
+function addStreamingBubble() {
+  const msgs = document.getElementById('messages');
+  const div = document.createElement('div');
+  div.className = 'msg';
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble bot';
+  bubble.innerHTML = '<span class="cursor"></span>';
+  div.appendChild(bubble);
+  msgs.appendChild(div);
+  msgs.scrollTop = msgs.scrollHeight;
+  return bubble;
+}
+
+function renderHistory() {
+  const msgs = document.getElementById('messages');
+  msgs.innerHTML = '';
+  if (history.length === 0) {
+    addBotMsg('🌿 ¡Hola! Soy tu asistente privado de cultivo. Tengo toda la info de tu CBD Auto en Torremolinos. Cuéntame en qué etapa está y en qué te puedo ayudar.');
+    return;
+  }
+  for (const m of history) {
+    if (m.role === 'user') {
+      // Strip the [Día X, etapa Y] prefix for display
+      const display = m.content.replace(/^\[Día \d+, etapa: [^\]]+\]\n/, '');
+      addUserMsg(display);
+    } else {
+      addBotMsg(m.content);
+    }
+  }
+}
+
+function clearConversation() {
+  if (history.length === 0) return;
+  if (!confirm('¿Borrar toda la conversación?')) return;
+  history = [];
+  saveHistory();
+  renderHistory();
+  renderQuick();
+}
+
+function renderQuick() {
+  const q = document.getElementById('quick');
+  q.innerHTML = '';
+  // Only show quick prompts when conversation is fresh
+  if (history.length > 0) { q.style.display = 'none'; return; }
+  q.style.display = 'flex';
+  QUICK.forEach(([text, emoji]) => {
+    const b = document.createElement('button');
+    b.className = 'qbtn';
+    b.textContent = `${emoji} ${text}`;
+    b.addEventListener('click', () => ask(text));
+    q.appendChild(b);
+  });
+}
+
+function ask(q) {
+  const input = document.getElementById('msginput');
+  input.value = q;
+  sendMsg();
+}
+
+// ------------ streaming API ------------
+async function* streamMessages(payload, signal) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    signal,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+    body: JSON.stringify({ ...payload, stream: true }),
+  });
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = await res.json();
+      message = body.error?.message || message;
+    } catch {}
+    throw new Error(message);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split('\n\n');
+    buffer = parts.pop() || '';
+    for (const part of parts) {
+      for (const line of part.split('\n')) {
+        if (!line.startsWith('data:')) continue;
+        const raw = line.slice(5).trim();
+        if (!raw || raw === '[DONE]') continue;
+        try {
+          const ev = JSON.parse(raw);
+          if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta') {
+            yield ev.delta.text;
+          } else if (ev.type === 'message_stop') {
+            return;
+          } else if (ev.type === 'error') {
+            throw new Error(ev.error?.message || 'stream error');
+          }
+        } catch (e) {
+          if (e instanceof SyntaxError) continue;
+          throw e;
+        }
+      }
+    }
+  }
+}
+
+// ------------ send ------------
+function setSending(on) {
+  const btn = document.getElementById('sendbtn');
+  const input = document.getElementById('msginput');
+  if (on) {
+    btn.classList.add('stop');
+    btn.textContent = '■';
+    btn.setAttribute('aria-label', 'Detener');
+    input.disabled = true;
+  } else {
+    btn.classList.remove('stop');
+    btn.textContent = '➤';
+    btn.setAttribute('aria-label', 'Enviar');
+    btn.disabled = false;
+    input.disabled = false;
+    input.focus();
+  }
+}
+
+async function sendMsg() {
+  if (currentAbort) {
+    currentAbort.abort();
+    currentAbort = null;
+    return;
+  }
+  const input = document.getElementById('msginput');
+  const text = input.value.trim();
+  if (!text) return;
+  input.value = '';
+  input.style.height = 'auto';
+
+  const stage = STAGES.find(s => s.id === currentStage) || STAGES[2];
+  const contextMsg = `[Día ${plantDay}, etapa: ${stage.label}]\n${text}`;
+
+  addUserMsg(text);
+  history.push({ role: 'user', content: contextMsg });
+  saveHistory();
+  renderQuick();
+
+  const bubble = addStreamingBubble();
+  setSending(true);
+  currentAbort = new AbortController();
+
+  let acc = '';
+  try {
+    const stream = streamMessages({
+      model: 'claude-opus-4-7',
+      max_tokens: 1024,
+      system: SYSTEM,
+      messages: history,
+      // Top-level auto-caching: as conversation grows past the model's
+      // minimum cacheable prefix, subsequent turns read from cache.
+      cache_control: { type: 'ephemeral' },
+    }, currentAbort.signal);
+
+    for await (const chunk of stream) {
+      acc += chunk;
+      bubble.innerHTML = renderMarkdown(acc) + '<span class="cursor"></span>';
+      const msgs = document.getElementById('messages');
+      msgs.scrollTop = msgs.scrollHeight;
+    }
+    bubble.innerHTML = renderMarkdown(acc);
+    history.push({ role: 'assistant', content: acc });
+    saveHistory();
+  } catch (e) {
+    const aborted = e.name === 'AbortError';
+    if (aborted && acc) {
+      bubble.innerHTML = renderMarkdown(acc) + ' <em>(detenido)</em>';
+      history.push({ role: 'assistant', content: acc });
+      saveHistory();
+    } else {
+      bubble.classList.add('error');
+      bubble.textContent = aborted ? 'Detenido.' : `⚠️ ${e.message}`;
+      // Roll back the user turn so conversation stays valid
+      history.pop();
+      saveHistory();
+    }
+  } finally {
+    currentAbort = null;
+    setSending(false);
+  }
+}
+
+// ------------ init ------------
+document.addEventListener('DOMContentLoaded', () => {
+  load();
+
+  if (apiKey) {
+    showMain();
+  } else {
+    document.getElementById('apikey-input').focus();
+  }
+
+  document.getElementById('apikey-btn').addEventListener('click', startApp);
+  document.getElementById('apikey-input').addEventListener('keydown', e => {
+    if (e.key === 'Enter') startApp();
+  });
+
+  document.querySelectorAll('.tab').forEach(t => {
+    t.addEventListener('click', () => showTab(t.dataset.tab));
+  });
+  document.querySelectorAll('.daybtn').forEach(b => {
+    b.addEventListener('click', () => changeDay(parseInt(b.dataset.day, 10)));
+  });
+
+  document.getElementById('sendbtn').addEventListener('click', sendMsg);
+  document.getElementById('clearbtn').addEventListener('click', clearConversation);
+  document.getElementById('logoutbtn').addEventListener('click', logout);
+  document.getElementById('menubtn').addEventListener('click', () => showTab('plant'));
+
+  const ta = document.getElementById('msginput');
+  ta.addEventListener('input', () => {
+    ta.style.height = 'auto';
+    ta.style.height = Math.min(ta.scrollHeight, 100) + 'px';
+  });
+  ta.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMsg(); }
+  });
+});
+</script>
+</body>
+</html>

--- a/growbot.py
+++ b/growbot.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""GrowBot Privado — asistente CLI para cultivo outdoor de CBD Auto en Torremolinos.
+
+Uso:
+    export ANTHROPIC_API_KEY=sk-ant-...
+    python3 growbot.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+from anthropic import Anthropic, APIError
+
+MODEL = "claude-opus-4-7"
+STATE_FILE = Path.home() / ".growbot.json"
+HISTORY_CAP = 40
+
+STAGES = [
+    ("germen", "Germinación"),
+    ("seedling", "Plántula"),
+    ("veg", "Vegetativo"),
+    ("preflor", "Prefloración"),
+    ("flora", "Floración"),
+    ("cosecha", "Cosecha"),
+]
+
+SYSTEM = (
+    "Eres GrowBot Privado, asistente experto en cultivo outdoor de cannabis CBD Auto "
+    "en Torremolinos, Málaga (España), costa mediterránea. Clima suave, mucho sol, "
+    "veranos cálidos y secos, inviernos templados. El usuario cultiva legalmente para "
+    "uso personal. Responde en español, claro y directo, con consejos prácticos y "
+    "seguros. Evita juicios morales. Si te preguntan por dosis de nutrientes, sé "
+    "conservador y explica señales de exceso. Incluye unidades métricas. Si falta "
+    "info clave (día, etapa, síntoma concreto), pide una aclaración breve antes de "
+    "recomendar."
+)
+
+QUICK = [
+    "Revisar riego de hoy",
+    "¿Signos de deficiencia?",
+    "Plan de nutrientes semanal",
+    "¿Cuándo cosechar?",
+    "Problemas de plagas frecuentes",
+]
+
+ANSI = {
+    "reset": "\033[0m",
+    "dim": "\033[2m",
+    "bold": "\033[1m",
+    "green": "\033[32m",
+    "cyan": "\033[36m",
+    "yellow": "\033[33m",
+    "red": "\033[31m",
+    "grey": "\033[90m",
+}
+
+
+def color(text: str, *styles: str) -> str:
+    return "".join(ANSI[s] for s in styles) + text + ANSI["reset"]
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"day": 1, "stage": "veg", "history": []}
+
+
+def save_state(state: dict) -> None:
+    state["history"] = state["history"][-HISTORY_CAP:]
+    STATE_FILE.write_text(json.dumps(state, ensure_ascii=False, indent=2))
+
+
+def print_banner(state: dict) -> None:
+    stage_label = dict(STAGES).get(state["stage"], state["stage"])
+    print(color("GrowBot Privado", "bold", "green"))
+    print(color(f"Torremolinos, Málaga  ·  {date.today().isoformat()}", "dim"))
+    print(color(f"Día {state['day']}  ·  Etapa: {stage_label}", "cyan"))
+    print(color("Comandos: /day N  /stage X  /clear  /quick  /help  /quit", "dim"))
+    print()
+
+
+def print_help() -> None:
+    print(color("Comandos disponibles:", "bold"))
+    print("  /day N       Fija el día del cultivo (entero)")
+    print("  /stage X     Cambia la etapa. Opciones:")
+    for key, label in STAGES:
+        print(f"               - {key:10s} {label}")
+    print("  /clear       Borra el historial")
+    print("  /quick       Muestra preguntas rápidas")
+    print("  /help        Muestra esta ayuda")
+    print("  /quit        Salir (también Ctrl+D)")
+    print()
+
+
+def print_quick() -> None:
+    print(color("Preguntas rápidas:", "bold"))
+    for i, q in enumerate(QUICK, 1):
+        print(f"  {i}. {q}")
+    print(color("Escribe el número o redacta tu pregunta.", "dim"))
+    print()
+
+
+def handle_command(cmd: str, state: dict) -> bool:
+    """Returns True if the command was handled, False if it should be treated as a message."""
+    parts = cmd.strip().split(maxsplit=1)
+    name = parts[0].lower()
+    arg = parts[1] if len(parts) > 1 else ""
+
+    if name in ("/quit", "/exit"):
+        save_state(state)
+        print(color("Hasta luego.", "dim"))
+        sys.exit(0)
+    if name == "/help":
+        print_help()
+        return True
+    if name == "/quick":
+        print_quick()
+        return True
+    if name == "/clear":
+        state["history"] = []
+        save_state(state)
+        print(color("Historial borrado.", "yellow"))
+        return True
+    if name == "/day":
+        try:
+            state["day"] = max(1, int(arg))
+            save_state(state)
+            print(color(f"Día fijado a {state['day']}.", "cyan"))
+        except ValueError:
+            print(color("Uso: /day <entero>", "red"))
+        return True
+    if name == "/stage":
+        valid = {k for k, _ in STAGES}
+        if arg in valid:
+            state["stage"] = arg
+            save_state(state)
+            print(color(f"Etapa: {dict(STAGES)[arg]}", "cyan"))
+        else:
+            print(color(f"Etapas válidas: {', '.join(valid)}", "red"))
+        return True
+    return False
+
+
+def stream_reply(client: Anthropic, state: dict, user_text: str) -> None:
+    prefix = f"[Día {state['day']}, etapa: {state['stage']}]\n"
+    user_turn = {"role": "user", "content": prefix + user_text}
+    messages = state["history"] + [user_turn]
+
+    print(color("GrowBot  ", "bold", "green"), end="", flush=True)
+    chunks: list[str] = []
+    try:
+        with client.messages.stream(
+            model=MODEL,
+            max_tokens=1024,
+            system=[{"type": "text", "text": SYSTEM, "cache_control": {"type": "ephemeral"}}],
+            messages=messages,
+        ) as stream:
+            for text in stream.text_stream:
+                chunks.append(text)
+                print(text, end="", flush=True)
+        print()
+    except KeyboardInterrupt:
+        print(color("  [interrumpido]", "yellow"))
+    except APIError as e:
+        print(color(f"\n[Error de API] {e}", "red"))
+        return
+
+    answer = "".join(chunks).strip()
+    if answer:
+        state["history"].append(user_turn)
+        state["history"].append({"role": "assistant", "content": answer})
+        save_state(state)
+
+
+def main() -> None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        try:
+            api_key = input("Pega tu ANTHROPIC_API_KEY: ").strip()
+        except EOFError:
+            print(color("Falta ANTHROPIC_API_KEY.", "red"))
+            sys.exit(1)
+    if not api_key:
+        print(color("Falta ANTHROPIC_API_KEY.", "red"))
+        sys.exit(1)
+
+    client = Anthropic(api_key=api_key)
+    state = load_state()
+    print_banner(state)
+
+    while True:
+        try:
+            raw = input(color("Tú> ", "bold", "cyan"))
+        except (EOFError, KeyboardInterrupt):
+            print()
+            save_state(state)
+            print(color("Hasta luego.", "dim"))
+            return
+
+        text = raw.strip()
+        if not text:
+            continue
+        if text.startswith("/"):
+            handle_command(text, state)
+            continue
+        if text.isdigit() and 1 <= int(text) <= len(QUICK):
+            text = QUICK[int(text) - 1]
+            print(color(f"   -> {text}", "dim"))
+
+        stream_reply(client, state, text)
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Single-file HTML chat assistant for CBD Auto outdoor cultivation in
Torremolinos, using the Anthropic API directly from the browser.

Improvements over the draft:
- Fixes broken CSS (universal selector, custom properties, straight quotes)
  that prevented the original styles from applying at all
- Upgrades model to claude-opus-4-7
- Streams responses via SSE with a live cursor and stop button
- Adds top-level prompt caching for multi-turn cost savings
- Persists API key, plant day/stage, and chat history in localStorage
- Replaces alert() with inline error bubbles; rolls back user turn on failure
  so the conversation stays valid
- Adds clear-chat, change-api-key, and basic markdown rendering
- Uses textContent for user input (XSS-safe) and escapes markdown source