### PR TITLE
Add Mini mundo abierto game (Three.js single-file artifact)

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,638 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Mini mundo abierto</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: #0b0e14; color: #e8ecf1;
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+    overflow: hidden; touch-action: none; }
+  #app { position: absolute; inset: 0; overflow: hidden; outline: none; }
+  canvas { display: block; width: 100%; height: 100%; touch-action: none; }
+
+  #hud { position: absolute; inset: 0; pointer-events: none; }
+  #hud .panel { position: absolute; background: rgba(14,18,26,.78);
+    border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 10px 12px;
+    backdrop-filter: blur(6px); pointer-events: auto; font-size: 13px; line-height: 1.35; }
+  #title { top: 12px; left: 12px; max-width: 420px; }
+  #title h1 { margin: 0 0 4px; font-size: 15px; letter-spacing: .3px; }
+  #title small { opacity: .75; }
+  #stats { top: 12px; right: 12px; min-width: 180px; text-align: right; }
+  #stats .row { display: flex; justify-content: space-between; gap: 10px; }
+  #stats b { color: #ffd86b; font-variant-numeric: tabular-nums; }
+  #controls { bottom: 12px; left: 12px; display: grid; grid-template-columns: auto auto; gap: 8px 14px; align-items: center; }
+  #controls .row { display: contents; }
+  #controls label { opacity: .85; }
+  #controls input[type=range] { width: 160px; vertical-align: middle; }
+  #controls input[type=number], #controls input[type=text] { width: 90px; background: #0f1420;
+    color: #e8ecf1; border: 1px solid rgba(255,255,255,.12); border-radius: 6px; padding: 4px 6px; }
+  #controls .actions { grid-column: 1 / span 2; display: flex; gap: 8px; flex-wrap: wrap; }
+  button { cursor: pointer; background: #1b2436; color: #e8ecf1;
+    border: 1px solid rgba(255,255,255,.12); border-radius: 8px; padding: 6px 10px; font-size: 13px; }
+  button:hover { background: #243049; }
+  button.primary { background: #2b5fff; border-color: transparent; }
+  button.primary:hover { background: #3a6bff; }
+  button.toggle.on { background: #2a7a45; border-color: transparent; }
+
+  #hint { bottom: 12px; right: 12px; opacity: .85; }
+  #loader { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    background: rgba(5,8,14,.9); z-index: 5; font-size: 14px; letter-spacing: .4px; }
+  #loader.hidden { display: none; }
+  #startOverlay { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    background: rgba(5,8,14,.55); z-index: 4; cursor: pointer; text-align: center; padding: 20px;
+    backdrop-filter: blur(2px); pointer-events: auto; }
+  #startOverlay.hidden { display: none; }
+  #startOverlay .big { font-size: 22px; font-weight: 600; margin-bottom: 8px; }
+  #startOverlay .hint { opacity: .85; max-width: 520px; font-size: 13px; }
+  @media (max-width: 640px) {
+    #title { max-width: calc(100% - 210px); }
+    #controls input[type=range] { width: 110px; }
+    #hint { display: none; }
+  }
+  #crosshair { position: absolute; top: 50%; left: 50%; width: 14px; height: 14px;
+    transform: translate(-50%,-50%); border: 1px solid rgba(255,255,255,.7);
+    border-radius: 50%; box-shadow: 0 0 6px rgba(0,0,0,.4); pointer-events: none; }
+  #crosshair::before, #crosshair::after { content: ""; position: absolute; background: rgba(255,255,255,.7); }
+  #crosshair::before { left: 50%; top: -5px; width: 1px; height: 4px; transform: translateX(-50%); }
+  #crosshair::after { left: 50%; bottom: -5px; width: 1px; height: 4px; transform: translateX(-50%); }
+  .kbd { display: inline-block; padding: 0 6px; border: 1px solid rgba(255,255,255,.18);
+    border-bottom-width: 2px; border-radius: 4px; font-size: 11px; background: #0f1420; }
+</style>
+</head>
+<body>
+<div id="app" tabindex="0">
+  <canvas id="view"></canvas>
+  <div id="startOverlay">
+    <div class="big">Clic para jugar</div>
+    <div class="hint">WASD/Flechas mover · Shift trote · Espacio galope · Ctrl frenar · Clic dispara</div>
+  </div>
+  <div id="hud">
+    <div id="title" class="panel">
+      <h1>Mini mundo abierto</h1>
+      <small><span class="kbd">WASD</span>/<span class="kbd">Flechas</span> mover •
+        <span class="kbd">Shift</span> trote • <span class="kbd">Espacio</span> galope •
+        <span class="kbd">Ctrl</span> frenar • <span class="kbd">Click</span> dispara</small>
+    </div>
+    <div id="stats" class="panel">
+      <div class="row"><span>Puntos</span><b id="score">0</b></div>
+      <div class="row"><span>Objetivos</span><b id="objs">0</b></div>
+      <div class="row"><span>Hora</span><b id="clock">06:00</b></div>
+      <div class="row"><span>Velocidad</span><b id="speed">0</b></div>
+    </div>
+    <div id="controls" class="panel">
+      <label><input type="checkbox" id="rain" /> Lluvia</label>
+      <label><input type="checkbox" id="pauseDay" /> Pausar día</label>
+
+      <label>Terreno (segmentos)</label>
+      <input type="range" id="segs" min="64" max="320" step="16" value="160" />
+
+      <label>calidad</label>
+      <input type="range" id="quality" min="0.5" max="2" step="0.1" value="1" />
+
+      <label>Amplitud relieve</label>
+      <input type="range" id="amp" min="0" max="80" step="1" value="28" />
+
+      <label>Semilla</label>
+      <input type="text" id="seed" value="flux-1" />
+
+      <div class="actions">
+        <button id="regen">Regenerar</button>
+        <button id="run" class="primary">Ejecutar / Reiniciar juego</button>
+      </div>
+    </div>
+    <div id="hint" class="panel">
+      Controles: <span class="kbd">WASD</span>/<span class="kbd">Flechas</span> •
+      <span class="kbd">Shift</span> trote • <span class="kbd">Espacio</span> galope •
+      <span class="kbd">Ctrl</span> frenar • <span class="kbd">Click</span> dispara
+    </div>
+    <div id="crosshair"></div>
+  </div>
+  <div id="loader">Cargando…</div>
+</div>
+
+<script type="importmap">
+{ "imports": {
+  "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+} }
+</script>
+
+<script type="module">
+let THREE;
+try {
+  THREE = await import("three");
+} catch (err) {
+  try { THREE = await import("https://unpkg.com/three@0.160.0/build/three.module.js"); }
+  catch (e2) {
+    document.getElementById("loader").textContent = "No se pudo cargar Three.js: " + (err?.message || err);
+    throw e2;
+  }
+}
+
+// ----------------- tiny deterministic PRNG + noise -----------------
+function hashSeed(s) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+// value-noise with bicubic-ish smoothing, good enough for terrain
+function makeNoise(seed) {
+  const rand = mulberry32(seed);
+  const size = 256;
+  const grid = new Float32Array(size * size);
+  for (let i = 0; i < grid.length; i++) grid[i] = rand() * 2 - 1;
+  const at = (x, y) => grid[((y & (size - 1)) * size) + (x & (size - 1))];
+  const smooth = t => t * t * (3 - 2 * t);
+  const noise2 = (x, y) => {
+    const xi = Math.floor(x), yi = Math.floor(y);
+    const xf = x - xi, yf = y - yi;
+    const u = smooth(xf), v = smooth(yf);
+    const a = at(xi, yi), b = at(xi + 1, yi), c = at(xi, yi + 1), d = at(xi + 1, yi + 1);
+    return (a * (1 - u) + b * u) * (1 - v) + (c * (1 - u) + d * u) * v;
+  };
+  const fbm = (x, y, oct = 5, lac = 2, gain = 0.5) => {
+    let amp = 1, freq = 1, sum = 0, norm = 0;
+    for (let i = 0; i < oct; i++) { sum += amp * noise2(x * freq, y * freq); norm += amp; amp *= gain; freq *= lac; }
+    return sum / norm;
+  };
+  return { noise2, fbm };
+}
+
+// ----------------- renderer / scene -----------------
+const canvas = document.getElementById("view");
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, powerPreference: "high-performance" });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.0;
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x9ec7ff);
+scene.fog = new THREE.Fog(0x9ec7ff, 80, 360);
+
+const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+camera.position.set(0, 12, 20);
+
+const sun = new THREE.DirectionalLight(0xfff2cc, 1.2);
+sun.position.set(60, 120, 40);
+sun.castShadow = true;
+sun.shadow.mapSize.set(1024, 1024);
+sun.shadow.camera.left = -120; sun.shadow.camera.right = 120;
+sun.shadow.camera.top = 120; sun.shadow.camera.bottom = -120;
+sun.shadow.camera.near = 1; sun.shadow.camera.far = 400;
+scene.add(sun);
+scene.add(sun.target);
+
+const hemi = new THREE.HemisphereLight(0xbfd8ff, 0x364026, 0.55);
+scene.add(hemi);
+
+const ambient = new THREE.AmbientLight(0xffffff, 0.05);
+scene.add(ambient);
+
+// ----------------- terrain -----------------
+const WORLD = 300; // world size in meters
+let terrainMesh = null;
+let heightSampler = null;
+let waterMesh = null;
+
+function buildTerrain({ segments = 224, amplitude = 28, seed = "flux-1" }) {
+  if (terrainMesh) {
+    scene.remove(terrainMesh);
+    terrainMesh.geometry.dispose();
+    terrainMesh.material.dispose();
+  }
+  const geo = new THREE.PlaneGeometry(WORLD, WORLD, segments, segments);
+  geo.rotateX(-Math.PI / 2);
+
+  const { fbm } = makeNoise(hashSeed(seed));
+  const pos = geo.attributes.position;
+  const colors = new Float32Array(pos.count * 3);
+  const freq = 0.012;
+  const hills = (x, z) => {
+    const base = fbm(x * freq, z * freq, 5) * amplitude;
+    const ridges = Math.pow(Math.abs(fbm(x * freq * 2 + 13.1, z * freq * 2 - 7.3, 3)), 1.4) * amplitude * 0.35;
+    const valley = -Math.max(0, 6 - Math.sqrt(x * x + z * z) * 0.04);
+    return base + ridges + valley;
+  };
+  const grass = new THREE.Color(0x4e8a3a);
+  const rock = new THREE.Color(0x6f6a5e);
+  const sand = new THREE.Color(0xc6b27a);
+  const snow = new THREE.Color(0xe9eef4);
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i), z = pos.getZ(i);
+    const h = hills(x, z);
+    pos.setY(i, h);
+    const slopeSample = hills(x + 1, z) - h;
+    const slope = Math.min(1, Math.abs(slopeSample) * 1.8);
+    let c = grass.clone();
+    if (h < 0.5) c.lerp(sand, Math.min(1, (0.5 - h) * 0.8 + 0.2));
+    if (slope > 0.35) c.lerp(rock, Math.min(1, (slope - 0.35) * 2));
+    if (h > amplitude * 0.55) c.lerp(snow, Math.min(1, (h - amplitude * 0.55) / (amplitude * 0.35)));
+    colors[i * 3] = c.r; colors[i * 3 + 1] = c.g; colors[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  geo.computeVertexNormals();
+  const mat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.96, metalness: 0.0, flatShading: false });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.receiveShadow = true;
+  mesh.castShadow = false;
+  scene.add(mesh);
+  terrainMesh = mesh;
+
+  heightSampler = (x, z) => {
+    const cx = THREE.MathUtils.clamp(x, -WORLD / 2 + 0.01, WORLD / 2 - 0.01);
+    const cz = THREE.MathUtils.clamp(z, -WORLD / 2 + 0.01, WORLD / 2 - 0.01);
+    return hills(cx, cz);
+  };
+
+  if (!waterMesh) {
+    const wgeo = new THREE.PlaneGeometry(WORLD * 1.2, WORLD * 1.2);
+    wgeo.rotateX(-Math.PI / 2);
+    const wmat = new THREE.MeshStandardMaterial({ color: 0x1f4f7a, transparent: true, opacity: 0.7, roughness: 0.2, metalness: 0.1 });
+    waterMesh = new THREE.Mesh(wgeo, wmat);
+    waterMesh.position.y = -0.4;
+    scene.add(waterMesh);
+  }
+
+  // scatter trees + rocks deterministically
+  scatterProps(seed, amplitude);
+}
+
+// ----------------- props (trees, rocks, targets) -----------------
+let propsGroup = null;
+let targets = [];
+function scatterProps(seed, amplitude) {
+  if (propsGroup) { scene.remove(propsGroup); propsGroup.traverse(o => { o.geometry?.dispose(); o.material?.dispose?.(); }); }
+  propsGroup = new THREE.Group();
+  scene.add(propsGroup);
+  targets = [];
+
+  const rand = mulberry32(hashSeed(seed) ^ 0x9e3779b9);
+  const trunkGeo = new THREE.CylinderGeometry(0.18, 0.28, 1.6, 6);
+  const leafGeo = new THREE.ConeGeometry(1.1, 2.6, 7);
+  const trunkMat = new THREE.MeshStandardMaterial({ color: 0x5a3a20, roughness: 1 });
+  const leafMat = new THREE.MeshStandardMaterial({ color: 0x2f6a2d, roughness: 0.95 });
+
+  const treeCount = 240;
+  for (let i = 0; i < treeCount; i++) {
+    const x = (rand() * 2 - 1) * (WORLD / 2 - 4);
+    const z = (rand() * 2 - 1) * (WORLD / 2 - 4);
+    const y = heightSampler(x, z);
+    if (y < 0.6 || y > amplitude * 0.55) continue;
+    const slope = Math.abs(heightSampler(x + 1, z) - y);
+    if (slope > 0.6) continue;
+    const s = 0.8 + rand() * 0.8;
+    const trunk = new THREE.Mesh(trunkGeo, trunkMat);
+    trunk.position.set(x, y + 0.8 * s, z);
+    trunk.scale.setScalar(s);
+    trunk.castShadow = true;
+    const leaf = new THREE.Mesh(leafGeo, leafMat);
+    leaf.position.set(x, y + 1.6 * s + 1.3 * s, z);
+    leaf.scale.setScalar(s);
+    leaf.castShadow = true;
+    propsGroup.add(trunk);
+    propsGroup.add(leaf);
+  }
+
+  const rockGeo = new THREE.DodecahedronGeometry(1, 0);
+  const rockMat = new THREE.MeshStandardMaterial({ color: 0x7a7060, roughness: 1 });
+  for (let i = 0; i < 90; i++) {
+    const x = (rand() * 2 - 1) * (WORLD / 2 - 4);
+    const z = (rand() * 2 - 1) * (WORLD / 2 - 4);
+    const y = heightSampler(x, z);
+    if (y < 0.2) continue;
+    const s = 0.4 + rand() * 1.6;
+    const r = new THREE.Mesh(rockGeo, rockMat);
+    r.position.set(x, y + s * 0.4, z);
+    r.rotation.set(rand() * 6, rand() * 6, rand() * 6);
+    r.scale.set(s, s * (0.6 + rand() * 0.6), s);
+    r.castShadow = true; r.receiveShadow = true;
+    propsGroup.add(r);
+  }
+
+  // targets (glowing orbs) to shoot
+  const tgeo = new THREE.IcosahedronGeometry(0.7, 0);
+  for (let i = 0; i < 14; i++) {
+    const color = new THREE.Color().setHSL(rand(), 0.9, 0.55);
+    const tmat = new THREE.MeshStandardMaterial({ color, emissive: color, emissiveIntensity: 1.2, roughness: 0.3 });
+    const t = new THREE.Mesh(tgeo, tmat);
+    let x, z, y, tries = 0;
+    do {
+      x = (rand() * 2 - 1) * (WORLD / 2 - 10);
+      z = (rand() * 2 - 1) * (WORLD / 2 - 10);
+      y = heightSampler(x, z);
+      tries++;
+    } while (y < 1 && tries < 8);
+    t.position.set(x, y + 1.2, z);
+    t.castShadow = true;
+    t.userData = { bob: Math.random() * Math.PI * 2, alive: true };
+    propsGroup.add(t);
+    targets.push(t);
+  }
+  document.getElementById("objs").textContent = targets.filter(t => t.userData.alive).length;
+}
+
+// ----------------- player -----------------
+const player = new THREE.Group();
+const body = new THREE.Mesh(
+  new THREE.BoxGeometry(1.1, 0.9, 2.0),
+  new THREE.MeshStandardMaterial({ color: 0x8a4a2a, roughness: 0.9 })
+);
+body.position.y = 1.2;
+body.castShadow = true;
+player.add(body);
+const head = new THREE.Mesh(
+  new THREE.BoxGeometry(0.6, 0.6, 0.8),
+  new THREE.MeshStandardMaterial({ color: 0x8a4a2a, roughness: 0.9 })
+);
+head.position.set(0, 1.9, -0.9);
+head.castShadow = true;
+player.add(head);
+const rider = new THREE.Mesh(
+  new THREE.CapsuleGeometry(0.28, 0.9, 4, 8),
+  new THREE.MeshStandardMaterial({ color: 0x223a7a, roughness: 0.8 })
+);
+rider.position.set(0, 2.3, 0.1);
+rider.castShadow = true;
+player.add(rider);
+for (const lx of [-0.45, 0.45]) for (const lz of [-0.7, 0.7]) {
+  const leg = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.14, 0.14, 1.1, 6),
+    new THREE.MeshStandardMaterial({ color: 0x3d2414, roughness: 1 })
+  );
+  leg.position.set(lx, 0.55, lz);
+  leg.castShadow = true;
+  leg.userData.leg = true;
+  leg.userData.phase = (lx < 0 ? 0 : Math.PI) + (lz < 0 ? 0 : Math.PI);
+  player.add(leg);
+}
+scene.add(player);
+
+// ----------------- bullets -----------------
+const bulletGeo = new THREE.SphereGeometry(0.12, 10, 10);
+const bulletMat = new THREE.MeshStandardMaterial({ color: 0xffd26b, emissive: 0xffaa33, emissiveIntensity: 1.8 });
+const bullets = [];
+function shoot() {
+  const b = new THREE.Mesh(bulletGeo, bulletMat);
+  b.castShadow = false;
+  const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.quaternion);
+  const up = new THREE.Vector3(0, 1, 0);
+  b.position.copy(player.position).addScaledVector(up, 2.1).addScaledVector(forward, 1.2);
+  const aim = forward.clone().setY(forward.y + 0.08).normalize();
+  b.userData.vel = aim.multiplyScalar(80);
+  b.userData.life = 1.6;
+  scene.add(b);
+  bullets.push(b);
+}
+
+// ----------------- rain -----------------
+let rainPts = null;
+function setRain(on) {
+  if (on && !rainPts) {
+    const n = 4000;
+    const geo = new THREE.BufferGeometry();
+    const pos = new Float32Array(n * 3);
+    const vel = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      pos[i * 3] = (Math.random() * 2 - 1) * 120;
+      pos[i * 3 + 1] = Math.random() * 80;
+      pos[i * 3 + 2] = (Math.random() * 2 - 1) * 120;
+      vel[i] = 40 + Math.random() * 30;
+    }
+    geo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
+    const mat = new THREE.PointsMaterial({ color: 0xbfd0e6, size: 0.12, transparent: true, opacity: 0.75 });
+    rainPts = new THREE.Points(geo, mat);
+    rainPts.userData.vel = vel;
+    scene.add(rainPts);
+  } else if (!on && rainPts) {
+    scene.remove(rainPts);
+    rainPts.geometry.dispose(); rainPts.material.dispose();
+    rainPts = null;
+  }
+}
+
+// ----------------- input -----------------
+const keys = new Set();
+const app = document.getElementById("app");
+const startOverlay = document.getElementById("startOverlay");
+function handleKey(e, down) {
+  if (["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "].includes(e.key)) e.preventDefault();
+  const k = e.key.toLowerCase();
+  if (down) keys.add(k); else keys.delete(k);
+  if (e.key === " ") down ? keys.add("space") : keys.delete("space");
+  if (e.key === "Shift") down ? keys.add("shift") : keys.delete("shift");
+  if (e.key === "Control") down ? keys.add("ctrl") : keys.delete("ctrl");
+}
+// listen on both window and app so it works whether the iframe or the app has focus
+for (const el of [window, app]) {
+  el.addEventListener("keydown", e => handleKey(e, true));
+  el.addEventListener("keyup", e => handleKey(e, false));
+}
+window.addEventListener("blur", () => keys.clear());
+function ensureFocus() { try { app.focus({ preventScroll: true }); } catch {} }
+app.addEventListener("pointerdown", () => {
+  ensureFocus();
+  if (!startOverlay.classList.contains("hidden")) {
+    startOverlay.classList.add("hidden");
+    running = true;
+  }
+});
+renderer.domElement.addEventListener("mousedown", e => {
+  ensureFocus();
+  if (e.button === 0 && startOverlay.classList.contains("hidden")) shoot();
+});
+// prevent context menu stealing right-click
+renderer.domElement.addEventListener("contextmenu", e => e.preventDefault());
+
+// ----------------- game state -----------------
+let score = 0;
+let time = 6 * 3600; // seconds in day
+let paused = false;
+let running = false;
+const speedEl = document.getElementById("speed");
+const scoreEl = document.getElementById("score");
+const objsEl = document.getElementById("objs");
+const clockEl = document.getElementById("clock");
+
+const vel = new THREE.Vector3();
+let heading = 0;
+let speed = 0;
+
+function reset() {
+  score = 0; scoreEl.textContent = "0";
+  time = 6 * 3600;
+  player.position.set(0, 0, 0);
+  heading = 0; speed = 0;
+  player.quaternion.identity();
+  for (const b of bullets) scene.remove(b);
+  bullets.length = 0;
+  running = true;
+}
+
+// ----------------- main loop -----------------
+const tmp = new THREE.Vector3();
+const clock = new THREE.Clock();
+function tick() {
+  const dt = Math.min(clock.getDelta(), 0.05);
+
+  if (running) {
+    // input -> heading/speed
+    const turn = (keys.has("a") || keys.has("arrowleft") ? 1 : 0) - (keys.has("d") || keys.has("arrowright") ? 1 : 0);
+    const fwd = (keys.has("w") || keys.has("arrowup") ? 1 : 0) - (keys.has("s") || keys.has("arrowdown") ? 1 : 0);
+    heading += turn * dt * 2.0 * (0.4 + speed / 20);
+    let target = 0;
+    if (fwd > 0) target = keys.has("space") ? 22 : keys.has("shift") ? 12 : 6;
+    else if (fwd < 0) target = -3;
+    if (keys.has("ctrl")) target = 0;
+    speed += (target - speed) * Math.min(1, dt * (keys.has("ctrl") ? 3.5 : 1.6));
+
+    const forward = new THREE.Vector3(-Math.sin(heading), 0, -Math.cos(heading));
+    player.position.addScaledVector(forward, speed * dt);
+    player.position.x = THREE.MathUtils.clamp(player.position.x, -WORLD / 2 + 2, WORLD / 2 - 2);
+    player.position.z = THREE.MathUtils.clamp(player.position.z, -WORLD / 2 + 2, WORLD / 2 - 2);
+    player.position.y = heightSampler ? heightSampler(player.position.x, player.position.z) : 0;
+    player.rotation.y = heading;
+
+    // leg bob
+    const bob = Math.abs(speed) * 1.2;
+    for (const child of player.children) {
+      if (!child.userData?.leg) continue;
+      child.rotation.x = Math.sin(performance.now() * 0.012 * (1 + speed * 0.1) + child.userData.phase) * Math.min(0.7, bob * 0.08);
+    }
+  }
+
+  // bullets
+  for (let i = bullets.length - 1; i >= 0; i--) {
+    const b = bullets[i];
+    b.position.addScaledVector(b.userData.vel, dt);
+    b.userData.vel.y -= 9.8 * dt;
+    b.userData.life -= dt;
+    // target collision
+    for (const t of targets) {
+      if (!t.userData.alive) continue;
+      if (b.position.distanceToSquared(t.position) < 0.9) {
+        t.userData.alive = false;
+        t.visible = false;
+        score += 100;
+        scoreEl.textContent = score;
+        objsEl.textContent = targets.filter(x => x.userData.alive).length;
+        b.userData.life = 0;
+        break;
+      }
+    }
+    const gy = heightSampler ? heightSampler(b.position.x, b.position.z) : -1;
+    if (b.userData.life <= 0 || b.position.y < gy) {
+      scene.remove(b);
+      bullets.splice(i, 1);
+    }
+  }
+
+  // targets bob
+  for (const t of targets) {
+    if (!t.userData.alive) continue;
+    t.userData.bob += dt * 2;
+    t.position.y += Math.sin(t.userData.bob) * dt * 0.4;
+    t.rotation.y += dt;
+  }
+
+  // camera chase
+  const camOffset = new THREE.Vector3(0, 5.5, 10.5).applyQuaternion(player.quaternion);
+  const camTarget = player.position.clone().add(camOffset);
+  camera.position.lerp(camTarget, Math.min(1, dt * 4.5));
+  tmp.copy(player.position).add(new THREE.Vector3(0, 1.6, 0));
+  camera.lookAt(tmp);
+
+  // day/night
+  if (!paused) time = (time + dt * 120) % 86400;
+  const t = time / 86400;
+  const angle = t * Math.PI * 2 - Math.PI / 2;
+  const sx = Math.cos(angle), sy = Math.sin(angle);
+  sun.position.set(sx * 180, Math.max(-30, sy * 220), 60);
+  sun.target.position.copy(player.position);
+  const dayness = THREE.MathUtils.clamp(sy * 1.4 + 0.2, 0, 1);
+  const night = new THREE.Color(0x0b1326);
+  const dusk = new THREE.Color(0xffa15a);
+  const noon = new THREE.Color(0x9ec7ff);
+  const sky = night.clone().lerp(dusk, THREE.MathUtils.smoothstep(dayness, 0, 0.35))
+    .lerp(noon, THREE.MathUtils.smoothstep(dayness, 0.25, 0.8));
+  scene.background = sky;
+  scene.fog.color.copy(sky);
+  sun.intensity = 0.1 + dayness * 1.3;
+  hemi.intensity = 0.15 + dayness * 0.6;
+
+  // clock HUD
+  const hh = Math.floor(time / 3600), mm = Math.floor((time % 3600) / 60);
+  clockEl.textContent = `${String(hh).padStart(2,"0")}:${String(mm).padStart(2,"0")}`;
+  speedEl.textContent = Math.round(Math.abs(speed) * 3.6) + " km/h";
+
+  // rain
+  if (rainPts) {
+    const pos = rainPts.geometry.attributes.position.array;
+    const vel = rainPts.userData.vel;
+    for (let i = 0; i < vel.length; i++) {
+      pos[i * 3 + 1] -= vel[i] * dt;
+      if (pos[i * 3 + 1] < 0) {
+        pos[i * 3] = player.position.x + (Math.random() * 2 - 1) * 80;
+        pos[i * 3 + 1] = 60 + Math.random() * 30;
+        pos[i * 3 + 2] = player.position.z + (Math.random() * 2 - 1) * 80;
+      }
+    }
+    rainPts.geometry.attributes.position.needsUpdate = true;
+  }
+
+  renderer.render(scene, camera);
+  requestAnimationFrame(tick);
+}
+
+// ----------------- resize + boot -----------------
+function resize() {
+  const q = parseFloat(document.getElementById("quality").value) || 1;
+  const rect = app.getBoundingClientRect();
+  const w = Math.max(1, Math.floor(rect.width));
+  const h = Math.max(1, Math.floor(rect.height));
+  camera.aspect = w / h; camera.updateProjectionMatrix();
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio * q, 2.5));
+  renderer.setSize(w, h, false);
+}
+window.addEventListener("resize", resize);
+if (typeof ResizeObserver !== "undefined") {
+  new ResizeObserver(resize).observe(app);
+}
+
+function regen() {
+  const segments = parseInt(document.getElementById("segs").value, 10);
+  const amp = parseFloat(document.getElementById("amp").value);
+  const seed = document.getElementById("seed").value || "flux-1";
+  buildTerrain({ segments, amplitude: amp, seed });
+  player.position.y = heightSampler(player.position.x, player.position.z);
+  objsEl.textContent = targets.filter(t => t.userData.alive).length;
+}
+
+document.getElementById("rain").addEventListener("change", e => setRain(e.target.checked));
+document.getElementById("pauseDay").addEventListener("change", e => { paused = e.target.checked; });
+document.getElementById("regen").addEventListener("click", regen);
+document.getElementById("run").addEventListener("click", () => { reset(); });
+document.getElementById("quality").addEventListener("change", resize);
+
+resize();
+regen();
+reset();
+running = false; // wait for user click on overlay
+document.getElementById("loader").classList.add("hidden");
+tick();
+ensureFocus();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Procedural terrain with seed/amplitude/segments controls, third-person
rider, WASD/Shift/Space/Ctrl movement, click-to-shoot targets, rain,
day/night cycle, and scoring. Optimized for chat artifact iframes:
ResizeObserver-based sizing, focus capture, click-to-start overlay, and
a CDN fallback for Three.js.

https://claude.ai/code/session_0194Hufu4qEVJQyEqeD4uXAa